### PR TITLE
fix: Overwriting (Re-Recording) on Android fails with null object ref…

### DIFF
--- a/android/src/main/java/com/reactlibrary/AudioRecorder/AudioRecording.java
+++ b/android/src/main/java/com/reactlibrary/AudioRecorder/AudioRecording.java
@@ -68,7 +68,8 @@ public class AudioRecording {
       // Remove timestamp string which is added automatically by Android
       String fileNameCleaned = fileName.substring(0, fileName.indexOf("?"));
 
-      this.filePath = fileNameCleaned;
+      //This should be set here properly  so that it can be later used in case of overwriting.
+      this.filePath = Environment.getExternalStorageDirectory() + "/" + fileNameCleaned;
     } else {
       this.isOverwriting = false;
     }
@@ -104,7 +105,7 @@ public class AudioRecording {
     // If in overwriting mode
     if (isOverwriting) {
       // Get the file which should be overwritten
-      String previousTape = destinationPath.getAbsolutePath();
+      String previousTape = filePath ;
       Movie originalFile = MovieCreator.build(previousTape);
       Movie originalFileCopy2 = MovieCreator.build(previousTape);
 
@@ -270,7 +271,7 @@ public class AudioRecording {
         ///
 
         // Delete temporary files
-        FileUtils.deleteFile(previousTape);
+//      FileUtils.deleteFile(previousTape); // Don't delete the original file (previous file which was given to startRecording).
         FileUtils.deleteFile(currentTape);
         FileUtils.deleteFile(originalCutTape);
         FileUtils.deleteFile(originalCurrentMergedTape);


### PR DESCRIPTION
Have fixed the null reference issue.

# Description
In actual the file which was given to `startRecording` method was not getting overwritten nor it was being touched in `stopRecording` method. The newly recorded file was being used as both `previousTape` and `currentTape` as per the code in `stopRecording` method.

The issue was arising because the mp4Parser was not able to make `Movie` instance  at ` Movie originalFile = MovieCreator.build(previousTape);`  with the audio given  to it as the type of `Box` type instance was different than needed (was getting `MediaDataBox` but needed was `MovieBox`) because of which `isoFile.getMovieBox()` ended up being null in `MovieCreator.java` at Line 51.

## Fixes (issue)
1. Changed file being given to be overwritten. 
2. Removed code to delete the source file (original file that gets overwritten)

## Type of change

- [ ] Logical Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

1. Record an audio while ensuring that `startRecording` is not given any params in `App.js`.
2. Open file explorer in Android Studio and look for a file under `/sdcard` that should have a name like `YYYY-MM-DD-hh-mm-ss--rec.mp4`. 
3. Go to App.js and search for the handleStartRecording method and fill in the filename as parameter e.g. `this.audioRecorderRef.startRecording('2018-11-27-11-20-21--rec.mp4?timestamp=12345', 0);`

## Expected Behavior:
A new file with same name format should be saved and the new file should have overwritten audio from a specific point of time (in milliseconds). 
