### PR TITLE
fix: android waveform formula and data (WIP)

### DIFF
--- a/android/src/main/java/com/reactlibrary/AudioPlayerPlot/AudioPlayerView.java
+++ b/android/src/main/java/com/reactlibrary/AudioPlayerPlot/AudioPlayerView.java
@@ -22,13 +22,15 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 // Represents the player plot waveform wrapper
 public class AudioPlayerView extends RelativeLayout {
   // The plot which represents the waveform
   private StaticWaveformView plot;
 
-  // The constructor
   public AudioPlayerView(Context context) {
     super(context);
 
@@ -68,33 +70,57 @@ public class AudioPlayerView extends RelativeLayout {
       if (event.lineColor != null) {
         this.plot.setLineColor(Color.parseColor(event.lineColor));
       }
-
       this.plot.setPixelsPerSecond(event.pixelsPerSecond);
+
     }
   }
 
   // Add the data to the plot (waveform)
-  private void updateWaveformWithData(String fileName)  {
-    // Remove timestamp parameter
-    String fileNameCleaned = fileName.substring(0, fileName.indexOf("?"));
+  private void updateWaveformWithData(String fileName) {
+      // Remove timestamp parameter
+      String fileNameCleaned = fileName.substring(0, fileName.indexOf("?"));
+     
+      // Get an instance of the file
+      File audioFile = new File(Environment.getExternalStorageDirectory().getAbsolutePath() + "/" + fileNameCleaned);
 
-    // Get an instance of the file
-    File audioFile = new File(Environment.getExternalStorageDirectory().getAbsolutePath() + "/" + fileNameCleaned);
+      // Read the file duration from the file meta data
+      Uri uri = Uri.parse(audioFile.getAbsolutePath());
+      MediaMetadataRetriever mmr = new MediaMetadataRetriever();
+      mmr.setDataSource(null, uri);
+      String durationStr = mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
+      float durationInMS = Float.parseFloat(durationStr);
 
-    // Read the file duration from the file meta data
-    Uri uri = Uri.parse(audioFile.getAbsolutePath());
-    MediaMetadataRetriever mmr = new MediaMetadataRetriever();
-    mmr.setDataSource(null, uri);
-    String durationStr = mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
-    float durationInMS = Float.parseFloat(durationStr);
+      // Set the duration
+      this.plot.setFileDuration(durationInMS);
 
-    // Set the duration
-    this.plot.setFileDuration(durationInMS);
+      // Read the file data
+      byte[] data = new byte[0];
+      try {
+          data = FileUtils.fileToBytes(audioFile);
+          short[] shorts = new short[data.length/2];
 
-    // Read the file data
-    byte[] data = FileUtils.fileToBytes(audioFile);
+          ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN).asShortBuffer().get(shorts);
 
-    // Set the plot data to be the data of the audio file
-    this.plot.setData(data);
+          for (int i = 0; i <shorts.length; i++) {
+              short currentShort = shorts[i];
+              currentShort = currentShort <0 ? (short) (currentShort*-1) : currentShort;
+              shorts[i] = currentShort;
+          }
+
+          this.plot.setMaxAmplitude(findLargest(shorts));
+          this.plot.setData(shorts);
+      } catch (IOException e) {
+          e.printStackTrace();
+      }
+  }
+
+  private short findLargest (short[] dataArray)  {
+      short maxShort = dataArray[0];
+      for(int i = 1; i<dataArray.length; i++) {
+          if (dataArray[i] > maxShort) {
+              maxShort = dataArray[i];
+          }
+      }
+      return maxShort;
   }
 }

--- a/android/src/main/java/com/reactlibrary/AudioPlayerPlot/StaticWaveformView.java
+++ b/android/src/main/java/com/reactlibrary/AudioPlayerPlot/StaticWaveformView.java
@@ -27,10 +27,10 @@ public class StaticWaveformView extends View {
   private Paint baseLine;
 
   // The file data
-  private byte[] bytes;
+  private short[] shorts;
 
   // The density of the waveform
-  private float density = 257;
+  private float density = 357f;
 
   // The background color of the waveform
   private int backgroundColor = Color.TRANSPARENT;
@@ -43,6 +43,8 @@ public class StaticWaveformView extends View {
 
   // The duration of the audio file to be visualized
   private float fileDuration = 0.0f;
+
+  private short maxAmplitude = 0;
 
   // Constructor
   public StaticWaveformView(Context context) {
@@ -101,21 +103,22 @@ public class StaticWaveformView extends View {
   // Draw the file data as waveform
   @Override
   protected void onDraw(Canvas canvas) {
+
+      //canvas.drawPaint(this.baseLine);
     // Get screen width
     DisplayMetrics metrics = getResources().getDisplayMetrics();
     int widthPixels = metrics.widthPixels;
 
-    // Calculate the plot width based on the number of pixels per second and the file duration
-    float calculatedPlotWidth = this.pixelsPerSecond.floatValue() * (this.fileDuration / 1000);
+   // Check if data is available
+    if (this.shorts != null) {
+        // Calculate the plot width based on the number of pixels per second and the file duration
+        float calculatedPlotWidth = this.shorts.length;
 
-    // Check if data is available
-    if (this.bytes != null) {
-      // Create a straight line before the file waveform so that it starts in the middle of the screen
-      canvas.drawLine(0, getHeight() / 2f, widthPixels / 2f, (getHeight() / 2f), this.baseLine);
+        // Create a straight line before the file waveform so that it starts in the middle of the screen
+     // canvas.drawLine(0, getHeight() / 2f, widthPixels / 2f, (getHeight() / 2f), this.baseLine);
 
       // Calculate the bar width based on the total plot width
-      float barWidth = (calculatedPlotWidth / this.density) * metrics.density;
-      float div = this.bytes.length / this.density;
+      float barWidth = 1.0f;
 
       // Set baseline settings
       this.baseLine.setColor(getResources().getColor(R.color.brandColor));
@@ -124,38 +127,39 @@ public class StaticWaveformView extends View {
       // Set plot settings
       this.waveform.setColor(getResources().getColor(R.color.brandColor));
       this.waveform.setStrokeWidth(5);
-
+        float canvasHeightOneSide = canvas.getHeight()/2f;
       // Calculate the bar position based on the given parameters
-      for (int i = 0; i < this.density; i++) {
-        int bytePosition = (int) Math.ceil(i * div);
-        int top = canvas.getHeight() / 2
-                + (128 - Math.abs(this.bytes[bytePosition]))
-                * (canvas.getHeight() / 2) / 128;
 
-        int bottom = canvas.getHeight() / 2
-                - (128 - Math.abs(this.bytes[bytePosition]))
-                * (canvas.getHeight() / 2) / 128;
+        for (int i = 0; i < this.shorts.length; i++) {
 
-        float barX = (i * barWidth) + (barWidth / 2);
+            float value = (float)(canvasHeightOneSide * (0.65f) * ((float) this.shorts[i]) * (1.0/maxAmplitude));
+            float top = canvasHeightOneSide + value;
+            float bottom = canvasHeightOneSide - value;
 
-        // Draw the waveform (mirrored)
-        canvas.drawLine(barX + widthPixels / 2f, bottom, barX + widthPixels / 2f, canvas.getHeight() / 2f, this.waveform);
-        canvas.drawLine(barX + widthPixels / 2f , top, barX + widthPixels / 2f, canvas.getHeight() / 2f, this.waveform);
-      }
+            float barX = (i * barWidth);
 
-      canvas.drawLine((widthPixels / 2f), (getHeight() / 2f), (widthPixels / 2f) + calculatedPlotWidth, (getHeight() / 2f), this.waveform);
+          // Draw the waveform (mirrored)
+          canvas.drawLine(barX + 0.0f , top + 0.0f, barX + barWidth, canvasHeightOneSide + 0.0f, this.waveform);
+          canvas.drawLine(barX + 0.0f, canvasHeightOneSide + 0.0f, barX + barWidth, bottom + 0.0f, this.waveform);
+        }
+
+      //canvas.drawLine((widthPixels / 2f), (getHeight() / 2f), (widthPixels / 2f) + calculatedPlotWidth, (getHeight() / 2f), this.waveform);
 
       // Draw the second part of the baseline after the waveform
-      canvas.drawLine((widthPixels / 2f) + (calculatedPlotWidth * metrics.density), (getHeight() / 2f), (widthPixels / 2f) + (calculatedPlotWidth * metrics.density) + (widthPixels / 2f), (getHeight() / 2f), this.baseLine);
+     // canvas.drawLine((widthPixels / 2f) + (calculatedPlotWidth * metrics.density), (getHeight() / 2f), (widthPixels / 2f) + (calculatedPlotWidth * metrics.density) + (widthPixels / 2f), (getHeight() / 2f), this.baseLine);
 
       super.onDraw(canvas);
     }
   }
 
   // Setter for file data
-  public void setData(byte[] bytes) {
+  public void setData(short[] bytes) {
     // Set the audio file data and redraw waveform
-    this.bytes = bytes;
+    this.shorts = bytes;
     this.invalidate();
   }
+
+    public void setMaxAmplitude(short maxAmplitude) {
+        this.maxAmplitude = maxAmplitude;
+    }
 }

--- a/android/src/main/java/com/reactlibrary/Helpers/FileUtils.java
+++ b/android/src/main/java/com/reactlibrary/Helpers/FileUtils.java
@@ -22,24 +22,19 @@ public class FileUtils {
   static final String OUTPUT_DIR = "";
 
   // Reads the bytes of a file
-  public static byte[] fileToBytes(File file) {
+  public static byte[] fileToBytes(File file) throws IOException {
     // Get the file size in bytes
-    int size = (int) file.length();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    BufferedInputStream in = new BufferedInputStream(new FileInputStream(file));
 
-    // Create the array where the bytes are stored in
-    byte[] bytes = new byte[size];
-
-    try {
-      // Read the bytes and store it in the array
-      BufferedInputStream buf = new BufferedInputStream(new FileInputStream(file));
-      buf.read(bytes, 0, bytes.length);
-      buf.close();
-    } catch (FileNotFoundException e) {
-      e.printStackTrace();
-    } catch (IOException e) {
-      e.printStackTrace();
+    int read;
+    byte[] buff = new byte[1024];
+    while ((read = in.read(buff)) > 0)
+    {
+      out.write(buff, 0, read);
     }
-    return bytes;
+    out.flush();
+    return out.toByteArray();
   }
 
   // Returns a Java File initialized to a directory of given name


### PR DESCRIPTION
#### Description
The audio being recorded is having 16-bit depth and the audio representation was lying on 8bit as bytes were used to derive the amplitude of the samples. Have changed the input byte[] to short[] as input to waveform rendering.

#### Fixes (issue)
Changed the input data format and have also changed the formula for deriving and rendering the audio samples.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
